### PR TITLE
Add Playwright smoke test and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,17 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "node test/run-tests.js"
+    "test": "playwright test",
+    "test:smoke": "playwright test tests/smoke.spec.ts",
+    "test:unit": "node test/run-tests.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "jsdom": "^26.1.0"
+    "@playwright/test": "^1.55.0",
+    "jsdom": "^26.1.0",
+    "playwright": "^1.55.0"
   }
 }

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect, chromium } from '@playwright/test';
+test('carrega página com extensão', async () => {
+  const EXT = process.env.EXT_DIR || './extension';
+  const ctx = await chromium.launchPersistentContext('tmp-user', {
+    headless: true,
+    args: [`--disable-extensions-except=${EXT}`, `--load-extension=${EXT}`],
+  });
+  const page = await ctx.newPage();
+  await page.goto('https://example.com');
+  await expect(page).toHaveTitle(/Example/i);
+  await ctx.close();
+});


### PR DESCRIPTION
## Summary
- configure npm scripts for Playwright smoke and unit tests
- add Playwright smoke test that loads the extension in Chromium

## Testing
- `npm run test:unit`
- `EXT_DIR=. npm run test:smoke` *(fails: net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ccbccfcc8331a6c3c3ad13049c85