### PR TITLE
feat: add Forja objective and Playwright setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,17 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "node test/run-tests.js"
+    "test": "playwright test",
+    "test:smoke": "playwright test tests/smoke.spec.ts",
+    "test:unit": "node test/run-tests.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "jsdom": "^26.1.0"
+    "@playwright/test": "^1.55.0",
+    "jsdom": "^26.1.0",
+    "playwright": "^1.55.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testDir: 'tests',
+};

--- a/popup.html
+++ b/popup.html
@@ -190,6 +190,9 @@
       <button id="toggleTheme" aria-label="Alternar tema">🌙</button>
       <button id="openChatGPT">Abrir ChatGPT</button>
     </header>
+    <p id="forjaObjective" style="font-size:0.9rem; text-align:center;">
+      Objetivo da Forja: Setup CI Playwright para extensão rodando verde (24h)
+    </p>
     <p style="font-size:0.85rem; margin-bottom:0.5em;">
       Configure os atalhos globais em
       <a id="openShortcuts" href="#">chrome://extensions/shortcuts</a>.<br>

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect, chromium } from '@playwright/test';
+test('carrega página com extensão', async () => {
+  const EXT = process.env.EXT_DIR || './extension';
+  const ctx = await chromium.launchPersistentContext('tmp-user', {
+    headless: true,
+    args: [`--disable-extensions-except=${EXT}`, `--load-extension=${EXT}`],
+    ignoreHTTPSErrors: true,
+  });
+  const page = await ctx.newPage();
+  await page.goto('https://example.com');
+  await expect(page).toHaveTitle(/Example/i);
+  await ctx.close();
+});


### PR DESCRIPTION
## Summary
- Display Forja's central objective in the popup
- Add Playwright-based smoke test and config
- Define npm scripts for Playwright and unit tests

## Testing
- `EXT_DIR=. npm test`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68a5ce9865788331b63d839203c138ff